### PR TITLE
fix(routes): add auth guard, remove user-resolver, add on found route…

### DIFF
--- a/src/app/account/account.component.ts
+++ b/src/app/account/account.component.ts
@@ -1,27 +1,27 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
+import { DASHBOARD_ROUTE, INFO_ROUTE, PROMPT_ROUTE } from '../core/constants/routes';
 
 @Component({
   selector: 'app-account',
   templateUrl: './account.component.html',
-  styleUrls: ['./account.component.scss']
+  styleUrls: ['./account.component.scss'],
 })
 export class AccountComponent implements OnInit {
-
-  constructor(private router: Router) { }
+  constructor(private router: Router) {}
 
   ngOnInit() {
-    window.scrollTo(0, 0)
+    window.scrollTo(0, 0);
   }
 
   edit() {
-    this.router.navigate(['/info']);
+    this.router.navigate(['/', INFO_ROUTE]);
   }
   add() {
-    this.router.navigate(['/prompt']);
+    this.router.navigate(['/', PROMPT_ROUTE]);
   }
   close() {
-    this.router.navigate(['/dashboard']);
+    this.router.navigate(['/', DASHBOARD_ROUTE]);
   }
   resource() {
     this.router.navigate(['/resources']);
@@ -29,5 +29,4 @@ export class AccountComponent implements OnInit {
   showContributors() {
     this.router.navigate(['/contributors']);
   }
-
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -28,8 +28,7 @@ import { PopupDialogComponent } from './resources/popup-dialog/popup-dialog.comp
 import { PromptModule } from './prompts/prompt.module';
 import { JwtInterceptor } from './interceptors/jwt.interceptor';
 import { Router } from '@angular/router';
-import {AmplifyAngularModule, AmplifyService} from 'aws-amplify-angular';
-import {configureAws} from './aws-cognito/config/awsconfig';
+import { AmplifyAngularModule, AmplifyService } from 'aws-amplify-angular';
 import { ContributorsComponent } from './contributors/contributors.component';
 
 @NgModule({
@@ -68,7 +67,6 @@ import { ContributorsComponent } from './contributors/contributors.component';
   bootstrap: [AppComponent],
 })
 export class AppModule {
-
   // constructor() {
   //   // TODO -- move config to login module based on selected option
   //   configureAws('CCE_Individual');

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -8,18 +8,25 @@ import { AccountComponent } from './account/account.component';
 import { ResourcesComponent } from './resources/resources.component';
 
 import { ModuleWithProviders } from '@angular/core';
-import { UserResolver } from './core/resolvers/user.resolver';
 import { AppComponent } from './app.component';
 import { PromptsComponent } from './prompts/prompts/prompts.component';
 import { InformationComponent } from './information/information/information.component';
 import { ContributorsComponent } from './contributors/contributors.component';
+import { AuthGuard } from './core/guards/auth.guard';
+import { WelcomePageComponent } from './auth/components/welcome-page/welcome.component';
+import { LoggedInRedirectGuard } from './core/guards/logged-in-redirect.guard';
+import { DASHBOARD_ROUTE, INFO_ROUTE, PROMPT_ROUTE, SIGNIN_ROUTE, WELCOME_ROUTE } from './core/constants/routes';
 
 export const appRoutes: Routes = [
   {
     path: '',
     component: AppComponent,
     children: [
-      // everything behind login goes here
+      {
+        path: WELCOME_ROUTE,
+        component: WelcomePageComponent,
+        canActivate: [LoggedInRedirectGuard],
+      },
       {
         path: 'resources',
         component: ResourcesComponent,
@@ -31,14 +38,14 @@ export const appRoutes: Routes = [
       {
         path: 'account',
         component: AccountComponent,
-        resolve: { user: UserResolver },
+        canActivate: [AuthGuard],
       },
       {
         path: 'pantry',
         component: PantryLocatorComponent,
       },
       {
-        path: 'signin',
+        path: SIGNIN_ROUTE,
         component: SignInComponent,
       },
       {
@@ -50,23 +57,24 @@ export const appRoutes: Routes = [
         component: RegisterComponent,
       },
       {
-        path: 'dashboard',
+        path: DASHBOARD_ROUTE,
         component: DashboardComponent,
-        resolve: { user: UserResolver },
+        canActivate: [AuthGuard],
       },
       {
-        path: 'prompt',
+        path: PROMPT_ROUTE,
         component: PromptsComponent,
-        resolve: { user: UserResolver },
+        canActivate: [AuthGuard],
       },
       {
-        path: 'info',
+        path: INFO_ROUTE,
         component: InformationComponent,
-        resolve: { user: UserResolver },
+        data: { allowNoProfile: true },
+        canActivate: [AuthGuard],
       },
       {
         path: '**',
-        redirectTo: '/',
+        redirectTo: `/${WELCOME_ROUTE}`,
         pathMatch: 'full',
       },
     ],

--- a/src/app/auth/routes/auth-routing.module.ts
+++ b/src/app/auth/routes/auth-routing.module.ts
@@ -1,15 +1,16 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
-import { SignInComponent } from '../components/sign-in/sign-in.component';
 import { PasswordResetComponent } from '../components/password-reset/password-reset.component';
 import { PasswordForgotComponent } from '../components/password-forgot/password-forgot.component';
 import { ValidateEmailComponent } from '../components/validate-email/validate-email.component';
 import { WelcomePageComponent } from '../components/welcome-page/welcome.component';
+import { LoggedInRedirectGuard } from '../../core/guards/logged-in-redirect.guard';
 
 const routes: Routes = [
   {
-    path: '',
-    component: WelcomePageComponent,//SignInComponent,
+    path: 'welcome',
+    component: WelcomePageComponent, // SignInComponent,
+    canActivate: [LoggedInRedirectGuard],
   },
   {
     path: 'passwordreset',

--- a/src/app/core/constants/routes.ts
+++ b/src/app/core/constants/routes.ts
@@ -2,3 +2,7 @@
 export const SIGNIN_ROUTE = 'signin';
 export const FORGET_PASSWORD_ROUTE = 'passwordforgot';
 export const RESET_PASSWORD_ROUTE = 'passwordreset';
+export const WELCOME_ROUTE = 'welcome';
+export const DASHBOARD_ROUTE = 'dashboard';
+export const INFO_ROUTE = 'info';
+export const PROMPT_ROUTE = 'prompt';

--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -1,44 +1,40 @@
-﻿import { fromRoleName } from '../../models/user-role-type.enum';
+﻿/**
+ * Guard to routes based on being autenticated
+ * Due to some info being in cognito and profile info being in a separate datastore
+ * there is an option property that can be used on routes with this guard
+ * allowNoProfile: true|false
+ * Default: false
+ */
 
 import { Injectable } from '@angular/core';
-import {
-  ActivatedRouteSnapshot,
-  CanActivate,
-  Router,
-  RouterStateSnapshot,
-} from '@angular/router';
-import { NavbarService } from '../services/navbar.service';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
+import { AuthenticationService } from '../services/cce/authentication.service';
+import { map, take } from 'rxjs/operators';
+import { WELCOME_ROUTE } from '../constants/routes';
 
 @Injectable({ providedIn: 'root' })
 export class AuthGuard implements CanActivate {
-  store = localStorage;
-
-  constructor(private router: Router, private navBarService: NavbarService) {}
+  constructor(private router: Router, private authenticationService: AuthenticationService) {}
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-    // const loggedInUser = !this.store.getItem('user') ? undefined : JSON.parse(this.store.getItem('user'));
-    // if (loggedInUser) {
-    //   this.userService.setUser(loggedInUser);
-    //   this.navBarService.setLogin(true);
-    // }
-    //
-    // const roles = route.data['roles'];
-    //
-    // let hasRole = false;
-    // for (const r of roles) {
-    //   if (this.userService.user && this.userService.hasRole(fromRoleName(r))) {
-    //     hasRole = true;
-    //     break;
-    //   }
-    // }
-    //
-    // if (this.authService.authorized && hasRole) {
-    //   return true;
-    // }
-    //
-    // this.authService.logout();
-    // this.router.navigate(['/signIn']);
-    // return false;
-    return true;
+    let allowNoProfile = false;
+    try {
+      allowNoProfile = !!route.data.allowNoProfile;
+    } catch (e) {}
+    return this.authenticationService.isLoggedIn$.pipe(
+      take(1),
+      map((loggedIn) => {
+        // WIP: need to resolve user profile and then observable before we continue
+        // const user = this.authenticationService.getUser();
+        // may need to move allowNoProfile to a resolver that attempt to get the userProfile if it DNE
+        // if (loggedIn && allowNoProfile === !!!user.userProfile) {
+        //   console.log('DEBUG Logged in user missing profile....logging user out');
+        //   this.authenticationService.logout(user.username).then(() => {
+        //       return false;
+        //   });
+        // }
+        return loggedIn ? loggedIn : this.router.createUrlTree(['/', WELCOME_ROUTE]);
+      })
+    );
   }
 }

--- a/src/app/core/guards/logged-in-redirect.guard.spec.ts
+++ b/src/app/core/guards/logged-in-redirect.guard.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, async, inject } from '@angular/core/testing';
+
+import { LoggedInRedirectGuard } from './logged-in-redirect.guard';
+
+describe('LoggedInRedirectGuard', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [LoggedInRedirectGuard]
+    });
+  });
+
+  it('should ...', inject([LoggedInRedirectGuard], (guard: LoggedInRedirectGuard) => {
+    expect(guard).toBeTruthy();
+  }));
+});

--- a/src/app/core/guards/logged-in-redirect.guard.ts
+++ b/src/app/core/guards/logged-in-redirect.guard.ts
@@ -1,0 +1,32 @@
+/**
+ * Guard to be used on UNAUTH paths such as welcome that should be redirect to dashboard if already logged in
+ */
+
+import { Injectable } from '@angular/core';
+import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree, Router } from '@angular/router';
+import { Observable } from 'rxjs';
+import { AuthenticationService } from '../services/cce/authentication.service';
+import { map, take } from 'rxjs/operators';
+import { DASHBOARD_ROUTE } from '../constants/routes';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LoggedInRedirectGuard implements CanActivate {
+  constructor(private router: Router, private authenticationService: AuthenticationService) {}
+  canActivate(
+    next: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    return this.authenticationService.isLoggedIn$.pipe(
+      take(1),
+      map((x) => {
+        const user = this.authenticationService.getUser();
+        if (!user || !user.userProfile) {
+          console.log('DEBUG user logged in, but is not valid ', user);
+        }
+        return x ? this.router.createUrlTree(['/', DASHBOARD_ROUTE]) : true;
+      })
+    );
+  }
+}

--- a/src/app/core/models/auth-state.model.ts
+++ b/src/app/core/models/auth-state.model.ts
@@ -1,0 +1,5 @@
+export interface AuthState {
+    isLoggedIn: boolean;
+    user: any | null;
+    hasUserProfile: boolean;
+}

--- a/src/app/dashboard/routes/dashboard-routing.module.ts
+++ b/src/app/dashboard/routes/dashboard-routing.module.ts
@@ -3,23 +3,25 @@ import { Routes, RouterModule } from '@angular/router';
 import { DashboardComponent } from '../components/dashboard.component';
 import { MetricsComponent } from '../components/metrics/metrics.component';
 import { AgreementDetailComponent } from '../components/agreement-detail/agreement-detail.component';
-import {UserResolver} from '../../core/resolvers/user.resolver';
+import { AuthGuard } from '../../core/guards/auth.guard';
+import { DASHBOARD_ROUTE } from '../../core/constants/routes';
 
 export const routes: Routes = [
   {
-    path: '',
+    path: DASHBOARD_ROUTE,
     component: DashboardComponent,
-    resolve: { user: UserResolver },
+    canActivate: [AuthGuard],
   },
   {
     path: 'metrics',
     component: MetricsComponent,
-    resolve: { user: UserResolver},
+    canActivate: [AuthGuard],
   },
   {
     path: 'agreement-detail',
     component: AgreementDetailComponent,
-  }
+    canActivate: [AuthGuard],
+  },
 ];
 
 @NgModule({

--- a/src/app/information/information-routing.module.ts
+++ b/src/app/information/information-routing.module.ts
@@ -1,11 +1,14 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { InformationComponent } from './information/information.component';
+import {AuthGuard} from '../core/guards/auth.guard';
 
 export const routes: Routes = [
   {
-    path: '',
+    path: 'info',
     component: InformationComponent,
+    data: { allowNoProfile: true },
+    canActivate: [AuthGuard],
   },
 ];
 

--- a/src/app/prompts/prompts-routing.module.ts
+++ b/src/app/prompts/prompts-routing.module.ts
@@ -1,14 +1,14 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { PromptsComponent } from 'src/app/prompts/prompts/prompts.component';
-import {UserResolver} from '../core/resolvers/user.resolver';
+import { AuthGuard } from '../core/guards/auth.guard';
 
 const routes: Routes = [
   {
-    path: '',
+    path: 'prompt',
     component: PromptsComponent,
-    resolve: { user: UserResolver },
-  }
+    canActivate: [AuthGuard],
+  },
 ];
 
 @NgModule({


### PR DESCRIPTION
… handling

- added auth guard
- removed user resolver (for now), tbd to use to load user and user profile
- updated routes to use auth guard and loggedin redirect guard

Updated routing behavior
 Not Logged In:
 user will go to welcome page, can directly navigate to other unauthenicated pages as they could previously

 Unspecified routes will all route back to / which will go to /welcome

 Logged In:
 If user goes back to /welcome or / , they will be routed to /dashboard

 If user tried to goto an unspecified route (e.g., /archer), they will be taken to / which will be the dashboard