### PR TITLE
reduce logo dashboard spacing

### DIFF
--- a/src/styles/components.scss
+++ b/src/styles/components.scss
@@ -50,11 +50,10 @@
   padding: 3rem 1.5rem 1.5rem 1.5rem;
   max-width: 1024px;
   margin: auto;
-  margin-bottom: 100px;
   overflow-y: scroll;
 
   &.tight {
-    padding: 1.5rem;
+    padding: 1.5rem 1.5rem 0 1.5rem;
   }
 }
 


### PR DESCRIPTION
removed bottom margin and reduced padding-bottom to reduce the space between the logo and the dashboard detail