### PR TITLE
119: refactor identityPoolId to be configuration based

### DIFF
--- a/src/app/aws-cognito/config/awsconfig.ts
+++ b/src/app/aws-cognito/config/awsconfig.ts
@@ -24,7 +24,7 @@ export const configureAws = (name: string) => {
       // Required only if it's different from Amazon Cognito Region
       // identityPoolRegion: 'XX-XXXX-X',
 
-      identityPoolId: 'us-west-2:812966e4-290a-4acb-98b6-b525023537ad',
+      identityPoolId: config.identityPoolId,
 
       // OPTIONAL - Amazon Cognito User Pool ID
       userPoolId: config.userPoolId,

--- a/src/app/aws-cognito/config/cup-info.model.ts
+++ b/src/app/aws-cognito/config/cup-info.model.ts
@@ -2,6 +2,7 @@ export interface CUPInfo {
   region: string;
   userPoolId: string;
   userPoolWebClientId: string;
+  identityPoolId?: string;
 }
 
 export interface CUPMap {

--- a/src/app/aws-cognito/config/individuals.ts
+++ b/src/app/aws-cognito/config/individuals.ts
@@ -6,5 +6,6 @@ export const individualsAWSInfo: CUPMap = {
     region: environment.aws.region,
     userPoolId: environment.aws.userPoolId,
     userPoolWebClientId: environment.aws.userPoolWebClientId,
+    identityPoolId: environment.aws.identityPoolId
   },
 };

--- a/src/environments/awsEnv.prod.ts
+++ b/src/environments/awsEnv.prod.ts
@@ -3,5 +3,6 @@ export const awsEnv = {
     region: 'us-west-2',
     userPoolId: 'us-west-2_igpmMslLS',
     userPoolWebClientId: '5bil759v27orpugcsmiq1698t6',
+    identityPoolId: 'us-west-2:3597b60c-c2ba-4ff2-8fbd-d343791d1b4e'
   },
 };

--- a/src/environments/awsEnv.qa.ts
+++ b/src/environments/awsEnv.qa.ts
@@ -3,5 +3,6 @@ export const awsEnv = {
     region: 'us-west-2',
     userPoolId: 'us-west-2_jARojIa5L',
     userPoolWebClientId: '31bl920mojee9npcb66mo7ipt4',
+    identityPoolId: 'us-west-2:812966e4-290a-4acb-98b6-b525023537ad',
   }
 };


### PR DESCRIPTION
I am unsure how to test this without deploying to production. That being said, I don't think there is harm in deploying to production but would love a second opinion. I verified that the dev config is still working when running locally