### PR TITLE
Task/131: settings screen [WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "generate": "graphql-codegen $GRAPHQL_API_URI $GRAPHQL_API_KEY"
+    "generate": "graphql-codegen $GRAPHQL_API_URI $GRAPHQL_API_KEY",
+    "generate:watch": "graphql-codegen --watch $GRAPHQL_API_URI $GRAPHQL_API_KEY"
   },
   "private": true,
   "dependencies": {

--- a/src/app/account/account.component.html
+++ b/src/app/account/account.component.html
@@ -1,55 +1,64 @@
 <app-site-header></app-site-header>
 
 <div class="account-container">
-    <div>
-        <h2 class="app-blue">
-            Updates on requests or shares?<br>
-            Start a new questionnaire.
-        </h2>
-    </div>
+  <div>
+    <h2 class="app-blue">
+      Updates on requests or shares?<br />
+      Start a new questionnaire.
+    </h2>
+  </div>
 
-    <div>
-        <button mat-flat-button color="primary" mat-fab color="primary" (click)="add()">
-            <mat-icon class="next">add</mat-icon>
-        </button>
-    </div>
+  <div>
+    <button mat-flat-button color="primary" mat-fab color="primary" (click)="add()">
+      <mat-icon class="next">add</mat-icon>
+    </button>
+  </div>
 
-    <div>
-        <h2 class="app-blue">
-            Edit your information.
-        </h2>
-    </div>
+  <div>
+    <h2 class="app-blue">
+      Edit your information.
+    </h2>
+  </div>
 
-    <div>
-        <button mat-flat-button color="primary" mat-fab color="primary" (click)="edit()">
-            <mat-icon class="next">edit</mat-icon>
-        </button>
-    </div>
+  <div>
+    <button mat-flat-button color="primary" mat-fab color="primary" (click)="edit()">
+      <mat-icon class="next">edit</mat-icon>
+    </button>
+  </div>
 
-    <div>
-        <h2 class="app-blue">
-            Resources
-        </h2>
-    </div>
+  <div>
+    <h2 class="app-blue">Settings</h2>
+  </div>
 
-    <div>
-        <button mat-flat-button color="primary" mat-fab color="primary" (click)="resource()">
-            <mat-icon class="next">help</mat-icon>
-        </button>
-    </div>
+  <div>
+    <button mat-flat-button color="primary" mat-fab color="primary" (click)="settings()">
+      <mat-icon class="next">settings</mat-icon>
+    </button>
+  </div>
 
-    <div>
-        <h2 class="app-blue">
-            Contributors
-        </h2>
-    </div>
+  <div>
+    <h2 class="app-blue">
+      Resources
+    </h2>
+  </div>
 
-    <div fxLayout="row" fxLayoutAlign="center center">
-        <button mat-flat-button color="primary" mat-fab color="primary" (click)="showContributors()">
-            <mat-icon class="next">group_work</mat-icon>
-        </button>
-    </div>
+  <div>
+    <button mat-flat-button color="primary" mat-fab color="primary" (click)="resource()">
+      <mat-icon class="next">help</mat-icon>
+    </button>
+  </div>
 
+  <div>
+    <h2 class="app-blue">
+      Contributors
+    </h2>
+  </div>
+
+  <div fxLayout="row" fxLayoutAlign="center center">
+    <button mat-flat-button color="primary" mat-fab color="primary" (click)="showContributors()">
+      <mat-icon class="next">group_work</mat-icon>
+    </button>
+  </div>
 </div>
 
 <app-site-footer></app-site-footer>

--- a/src/app/account/account.component.html
+++ b/src/app/account/account.component.html
@@ -6,9 +6,7 @@
       Updates on requests or shares?<br />
       Start a new questionnaire.
     </h2>
-  </div>
 
-  <div>
     <button mat-flat-button color="primary" mat-fab color="primary" (click)="add()">
       <mat-icon class="next">add</mat-icon>
     </button>
@@ -18,9 +16,7 @@
     <h2 class="app-blue">
       Edit your information.
     </h2>
-  </div>
 
-  <div>
     <button mat-flat-button color="primary" mat-fab color="primary" (click)="edit()">
       <mat-icon class="next">edit</mat-icon>
     </button>
@@ -28,9 +24,7 @@
 
   <div>
     <h2 class="app-blue">Settings</h2>
-  </div>
 
-  <div>
     <button mat-flat-button color="primary" mat-fab color="primary" (click)="settings()">
       <mat-icon class="next">settings</mat-icon>
     </button>
@@ -40,9 +34,7 @@
     <h2 class="app-blue">
       Resources
     </h2>
-  </div>
 
-  <div>
     <button mat-flat-button color="primary" mat-fab color="primary" (click)="resource()">
       <mat-icon class="next">help</mat-icon>
     </button>
@@ -52,12 +44,12 @@
     <h2 class="app-blue">
       Contributors
     </h2>
-  </div>
 
-  <div fxLayout="row" fxLayoutAlign="center center">
-    <button mat-flat-button color="primary" mat-fab color="primary" (click)="showContributors()">
-      <mat-icon class="next">group_work</mat-icon>
-    </button>
+    <div fxLayout="row" fxLayoutAlign="center center">
+      <button mat-flat-button color="primary" mat-fab color="primary" (click)="showContributors()">
+        <mat-icon class="next">group_work</mat-icon>
+      </button>
+    </div>
   </div>
 </div>
 

--- a/src/app/account/account.component.scss
+++ b/src/app/account/account.component.scss
@@ -1,13 +1,20 @@
 mat-icon {
-    color: white;
+  color: white;
 }
 
-.account-container{
-    text-align: center;
-    margin-bottom: 200px;
+.account-container {
+  text-align: center;
+  margin-bottom: 200px;
+
+  h2 {
+    margin-bottom: 0.25rem;
+  }
+
+  & > * {
+    margin-bottom: 2rem;
+  }
 }
 
-.contentspacing{
-    margin-top: 60px;
+.contentspacing {
+  margin-top: 60px;
 }
-

--- a/src/app/account/account.component.ts
+++ b/src/app/account/account.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { DASHBOARD_ROUTE, INFO_ROUTE, PROMPT_ROUTE } from '../core/constants/routes';
+import { DASHBOARD_ROUTE, INFO_ROUTE, PROMPT_ROUTE, SETTINGS_ROUTE, RESOURCES_ROUTE, CONTRIBUTORS_ROUTE } from '../core/constants/routes';
 
 @Component({
   selector: 'app-account',
@@ -24,9 +24,12 @@ export class AccountComponent implements OnInit {
     this.router.navigate(['/', DASHBOARD_ROUTE]);
   }
   resource() {
-    this.router.navigate(['/resources']);
+    this.router.navigate(['/', RESOURCES_ROUTE]);
   }
   showContributors() {
-    this.router.navigate(['/contributors']);
+    this.router.navigate(['/', CONTRIBUTORS_ROUTE]);
+  }
+  settings() {
+    this.router.navigate(['/', SETTINGS_ROUTE]);
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -32,6 +32,7 @@ import { ContributorsComponent } from './contributors/contributors.component';
 import { NearbyItemsComponent } from './dashboard/components/nearby-items/nearby-items.component';
 import { NearbyRequestsComponent } from './dashboard/components/nearby-requests/nearby-requests.component';
 import { NearbySharesComponent } from './dashboard/components/nearby-shares/nearby-shares.component';
+import { SettingsComponent } from './settings/settings.component';
 
 @NgModule({
   imports: [
@@ -58,12 +59,23 @@ import { NearbySharesComponent } from './dashboard/components/nearby-shares/near
     ToastrModule.forRoot(),
     LayoutModule,
   ],
-  declarations: [AppComponent, ContactUsComponent, AccountComponent, ResourcesComponent, PopupDialogComponent, ContributorsComponent, NearbyItemsComponent, NearbyRequestsComponent, NearbySharesComponent],
+  declarations: [
+    AppComponent,
+    ContactUsComponent,
+    AccountComponent,
+    ResourcesComponent,
+    PopupDialogComponent,
+    ContributorsComponent,
+    NearbyItemsComponent,
+    NearbyRequestsComponent,
+    NearbySharesComponent,
+    SettingsComponent,
+  ],
   providers: [
     AmplifyService,
     NavbarService,
     { provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true },
-    { provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true }
+    { provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true },
   ],
   exports: [],
   bootstrap: [AppComponent],

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -15,7 +15,17 @@ import { ContributorsComponent } from './contributors/contributors.component';
 import { AuthGuard } from './core/guards/auth.guard';
 import { WelcomePageComponent } from './auth/components/welcome-page/welcome.component';
 import { LoggedInRedirectGuard } from './core/guards/logged-in-redirect.guard';
-import { DASHBOARD_ROUTE, INFO_ROUTE, PROMPT_ROUTE, SIGNIN_ROUTE, WELCOME_ROUTE } from './core/constants/routes';
+import { SettingsComponent } from './settings/settings.component';
+import {
+  DASHBOARD_ROUTE,
+  INFO_ROUTE,
+  PROMPT_ROUTE,
+  SIGNIN_ROUTE,
+  WELCOME_ROUTE,
+  RESOURCES_ROUTE,
+  CONTRIBUTORS_ROUTE,
+  SETTINGS_ROUTE,
+} from './core/constants/routes';
 
 export const appRoutes: Routes = [
   {
@@ -28,11 +38,11 @@ export const appRoutes: Routes = [
         canActivate: [LoggedInRedirectGuard],
       },
       {
-        path: 'resources',
+        path: RESOURCES_ROUTE,
         component: ResourcesComponent,
       },
       {
-        path: 'contributors',
+        path: CONTRIBUTORS_ROUTE,
         component: ContributorsComponent,
       },
       {
@@ -70,6 +80,11 @@ export const appRoutes: Routes = [
         path: INFO_ROUTE,
         component: InformationComponent,
         data: { allowNoProfile: true },
+        canActivate: [AuthGuard],
+      },
+      {
+        path: SETTINGS_ROUTE,
+        component: SettingsComponent,
         canActivate: [AuthGuard],
       },
       {

--- a/src/app/core/constants/routes.ts
+++ b/src/app/core/constants/routes.ts
@@ -5,3 +5,6 @@ export const DASHBOARD_ROUTE = 'dashboard';
 export const INFO_ROUTE = 'info';
 export const PROMPT_ROUTE = 'prompt';
 export const SIGNIN_ROUTE = 'signin';
+export const SETTINGS_ROUTE = 'settings';
+export const RESOURCES_ROUTE = 'resources';
+export const CONTRIBUTORS_ROUTE = 'contributors';

--- a/src/app/graphql/generatedSDK.ts
+++ b/src/app/graphql/generatedSDK.ts
@@ -1189,10 +1189,12 @@ export type User = {
   /** @deprecated Field no longer supported */
   pickupRadius: Scalars['Short'];
   postalCode?: Maybe<Scalars['String']>;
+  receiveAcrossRoleBoundary: Scalars['Boolean'];
   requestOrders?: Maybe<Array<Maybe<Order>>>;
   requestOrderSummaries?: Maybe<Array<Maybe<OrderSummary>>>;
   sendEmailMatchNotifications: Scalars['Boolean'];
   sendEmailMessageNotifications: Scalars['Boolean'];
+  shareAcrossRoleBoundary: Scalars['Boolean'];
   shareOrders?: Maybe<Array<Maybe<Order>>>;
   shareOrderSummaries?: Maybe<Array<Maybe<OrderSummary>>>;
   state?: Maybe<Scalars['String']>;
@@ -1454,10 +1456,14 @@ export type UserFilter = {
   postalCode_not_in?: Maybe<Array<Maybe<Scalars['String']>>>;
   postalCode_not_starts_with?: Maybe<Scalars['String']>;
   postalCode_starts_with?: Maybe<Scalars['String']>;
+  receiveAcrossRoleBoundary?: Maybe<Scalars['Boolean']>;
+  receiveAcrossRoleBoundary_not?: Maybe<Scalars['Boolean']>;
   sendEmailMatchNotifications?: Maybe<Scalars['Boolean']>;
   sendEmailMatchNotifications_not?: Maybe<Scalars['Boolean']>;
   sendEmailMessageNotifications?: Maybe<Scalars['Boolean']>;
   sendEmailMessageNotifications_not?: Maybe<Scalars['Boolean']>;
+  shareAcrossRoleBoundary?: Maybe<Scalars['Boolean']>;
+  shareAcrossRoleBoundary_not?: Maybe<Scalars['Boolean']>;
   state?: Maybe<Scalars['String']>;
   state_contains?: Maybe<Scalars['String']>;
   state_ends_with?: Maybe<Scalars['String']>;
@@ -1528,6 +1534,22 @@ export type CreateOrderNoteMutation = (
   & { createOrderNote?: Maybe<(
     { __typename?: 'CreateNotePayload' }
     & Pick<CreateNotePayload, 'clientMutationId'>
+  )> }
+);
+
+export type UpdateUserSettingsMutationVariables = {
+  input: SaveUserInput;
+};
+
+
+export type UpdateUserSettingsMutation = (
+  { __typename?: 'Mutation' }
+  & { saveUser?: Maybe<(
+    { __typename?: 'UserMutationPayload' }
+    & { user?: Maybe<(
+      { __typename?: 'User' }
+      & Pick<User, 'id' | 'shareAcrossRoleBoundary' | 'receiveAcrossRoleBoundary' | 'sendEmailMatchNotifications'>
+    )> }
   )> }
 );
 
@@ -1623,6 +1645,19 @@ export type NearbySharesQuery = (
   )> }
 );
 
+export type UserSettingsQueryVariables = {
+  userId: Scalars['ID'];
+};
+
+
+export type UserSettingsQuery = (
+  { __typename?: 'Query' }
+  & { user?: Maybe<(
+    { __typename?: 'User' }
+    & Pick<User, 'id' | 'shareAcrossRoleBoundary' | 'receiveAcrossRoleBoundary' | 'sendEmailMatchNotifications'>
+  )> }
+);
+
 export const ArchiveItemDocument = gql`
     mutation ArchiveItem($input: ArchiveItemInput!) {
   archiveItem(input: $input) {
@@ -1670,6 +1705,26 @@ export const CreateOrderNoteDocument = gql`
   })
   export class CreateOrderNoteGQL extends Apollo.Mutation<CreateOrderNoteMutation, CreateOrderNoteMutationVariables> {
     document = CreateOrderNoteDocument;
+    
+  }
+export const UpdateUserSettingsDocument = gql`
+    mutation UpdateUserSettings($input: SaveUserInput!) {
+  saveUser(input: $input) {
+    user {
+      id
+      shareAcrossRoleBoundary
+      receiveAcrossRoleBoundary
+      sendEmailMatchNotifications
+    }
+  }
+}
+    `;
+
+  @Injectable({
+    providedIn: 'root'
+  })
+  export class UpdateUserSettingsGQL extends Apollo.Mutation<UpdateUserSettingsMutation, UpdateUserSettingsMutationVariables> {
+    document = UpdateUserSettingsDocument;
     
   }
 export const UpdateOrderDocument = gql`
@@ -1842,6 +1897,24 @@ export const NearbySharesDocument = gql`
     document = NearbySharesDocument;
     
   }
+export const UserSettingsDocument = gql`
+    query UserSettings($userId: ID!) {
+  user(userId: $userId) {
+    id
+    shareAcrossRoleBoundary
+    receiveAcrossRoleBoundary
+    sendEmailMatchNotifications
+  }
+}
+    `;
+
+  @Injectable({
+    providedIn: 'root'
+  })
+  export class UserSettingsGQL extends Apollo.Query<UserSettingsQuery, UserSettingsQueryVariables> {
+    document = UserSettingsDocument;
+    
+  }
 
   type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
@@ -1863,11 +1936,13 @@ export const NearbySharesDocument = gql`
       private archiveItemGql: ArchiveItemGQL,
       private createMatchGql: CreateMatchGQL,
       private createOrderNoteGql: CreateOrderNoteGQL,
+      private updateUserSettingsGql: UpdateUserSettingsGQL,
       private updateOrderGql: UpdateOrderGQL,
       private dashboardGql: DashboardGQL,
       private itemDetailsGql: ItemDetailsGQL,
       private nearbyRequestsGql: NearbyRequestsGQL,
-      private nearbySharesGql: NearbySharesGQL
+      private nearbySharesGql: NearbySharesGQL,
+      private userSettingsGql: UserSettingsGQL
     ) {}
       
     archiveItem(variables: ArchiveItemMutationVariables, options?: MutationOptionsAlone<ArchiveItemMutation, ArchiveItemMutationVariables>) {
@@ -1880,6 +1955,10 @@ export const NearbySharesDocument = gql`
     
     createOrderNote(variables: CreateOrderNoteMutationVariables, options?: MutationOptionsAlone<CreateOrderNoteMutation, CreateOrderNoteMutationVariables>) {
       return this.createOrderNoteGql.mutate(variables, options)
+    }
+    
+    updateUserSettings(variables: UpdateUserSettingsMutationVariables, options?: MutationOptionsAlone<UpdateUserSettingsMutation, UpdateUserSettingsMutationVariables>) {
+      return this.updateUserSettingsGql.mutate(variables, options)
     }
     
     updateOrder(variables: UpdateOrderMutationVariables, options?: MutationOptionsAlone<UpdateOrderMutation, UpdateOrderMutationVariables>) {
@@ -1916,5 +1995,13 @@ export const NearbySharesDocument = gql`
     
     nearbySharesWatch(variables: NearbySharesQueryVariables, options?: WatchQueryOptionsAlone<NearbySharesQueryVariables>) {
       return this.nearbySharesGql.watch(variables, options)
+    }
+    
+    userSettings(variables: UserSettingsQueryVariables, options?: QueryOptionsAlone<UserSettingsQueryVariables>) {
+      return this.userSettingsGql.fetch(variables, options)
+    }
+    
+    userSettingsWatch(variables: UserSettingsQueryVariables, options?: WatchQueryOptionsAlone<UserSettingsQueryVariables>) {
+      return this.userSettingsGql.watch(variables, options)
     }
   }

--- a/src/app/graphql/mutations/settings.graphql
+++ b/src/app/graphql/mutations/settings.graphql
@@ -1,0 +1,10 @@
+mutation UpdateUserSettings($input: SaveUserInput!) {
+  saveUser(input: $input) {
+    user {
+      id
+      shareAcrossRoleBoundary
+      receiveAcrossRoleBoundary
+      sendEmailMatchNotifications
+    }
+  }
+}

--- a/src/app/graphql/queries/settings.graphql
+++ b/src/app/graphql/queries/settings.graphql
@@ -1,0 +1,8 @@
+query UserSettings($userId: ID!) {
+  user(userId: $userId) {
+    id
+    shareAcrossRoleBoundary
+    receiveAcrossRoleBoundary
+    sendEmailMatchNotifications
+  }
+}

--- a/src/app/material/material.module.ts
+++ b/src/app/material/material.module.ts
@@ -25,6 +25,7 @@ import {
   MatListModule,
   MatRadioModule,
   MatCheckboxModule,
+  MatSlideToggleModule,
 } from '@angular/material';
 // import { MaterialFileInputModule } from 'ngx-material-file-input';
 //
@@ -57,6 +58,7 @@ import {
     MatListModule,
     MatRadioModule,
     MatCheckboxModule,
+    MatSlideToggleModule,
   ],
   exports: [
     CommonModule,
@@ -85,6 +87,7 @@ import {
     MatListModule,
     MatRadioModule,
     MatCheckboxModule,
+    MatSlideToggleModule,
   ],
 })
 export class CustomMaterialModule {}

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -16,7 +16,7 @@
 
     <div class="settings__toggle">
       <mat-slide-toggle class="app-blue" color="primary" [checked]="shareAcross" (change)="toggleShareAcross($event)" [disabled]="loading">
-        Share with ...
+        Share with {{ isUser ? 'Organizations' : 'Individuals' }}
       </mat-slide-toggle>
     </div>
 
@@ -28,7 +28,7 @@
         (change)="toggleReceiveFrom($event)"
         [disabled]="loading"
       >
-        Receive from ...
+        Receive from {{ isUser ? 'Organizations' : 'Individuals' }}
       </mat-slide-toggle>
     </div>
   </div>

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -1,0 +1,11 @@
+<app-site-header></app-site-header>
+
+<div class="settings-container">
+  <div>
+    <h2 class="app-blue">
+      Settings
+    </h2>
+  </div>
+</div>
+
+<app-site-footer></app-site-footer>

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -1,10 +1,36 @@
-<app-site-header></app-site-header>
-
-<div class="settings-container">
-  <div>
+<div class="settings">
+  <div class="settings__header" fxLayout="row" fxLayoutAlign="space-between center">
     <h2 class="app-blue">
-      Settings
+      Account Settings
     </h2>
+    <mat-icon (click)="back()">highlight_off</mat-icon>
+  </div>
+  <mat-progress-bar mode="indeterminate" *ngIf="loading" fxFill></mat-progress-bar>
+
+  <div fxLayout="column" class="settings__toggles">
+    <div class="settings__toggle">
+      <mat-slide-toggle class="app-blue" color="primary" [checked]="email" (change)="toggleEmail($event)" [disabled]="loading">
+        Email
+      </mat-slide-toggle>
+    </div>
+
+    <div class="settings__toggle">
+      <mat-slide-toggle class="app-blue" color="primary" [checked]="shareAcross" (change)="toggleShareAcross($event)" [disabled]="loading">
+        Share with ...
+      </mat-slide-toggle>
+    </div>
+
+    <div class="settings__toggle">
+      <mat-slide-toggle
+        class="app-blue"
+        color="primary"
+        [checked]="receiveAcross"
+        (change)="toggleReceiveFrom($event)"
+        [disabled]="loading"
+      >
+        Receive from ...
+      </mat-slide-toggle>
+    </div>
   </div>
 </div>
 

--- a/src/app/settings/settings.component.scss
+++ b/src/app/settings/settings.component.scss
@@ -1,12 +1,23 @@
-mat-icon {
-  color: white;
-}
+@import '../../styles/theme.scss';
 
-.settings-container {
-  text-align: center;
+.settings {
   margin-bottom: 200px;
-}
+  padding: 1rem 2rem;
 
-.contentspacing {
-  margin-top: 60px;
+  mat-icon {
+    color: gray;
+    width: 2rem;
+    height: 2rem;
+  }
+
+  &__header {
+    margin-bottom: 2rem;
+  }
+
+  &__toggle {
+    margin-bottom: 1rem;
+    &:last-of-type {
+      margin-bottom: 0;
+    }
+  }
 }

--- a/src/app/settings/settings.component.scss
+++ b/src/app/settings/settings.component.scss
@@ -3,6 +3,8 @@
 .settings {
   margin-bottom: 200px;
   padding: 1rem 2rem;
+  max-width: 32rem;
+  margin: 0 auto;
 
   mat-icon {
     color: gray;

--- a/src/app/settings/settings.component.scss
+++ b/src/app/settings/settings.component.scss
@@ -1,0 +1,12 @@
+mat-icon {
+  color: white;
+}
+
+.settings-container {
+  text-align: center;
+  margin-bottom: 200px;
+}
+
+.contentspacing {
+  margin-top: 60px;
+}

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -1,14 +1,87 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Router } from '@angular/router';
+import { CceSDK, UserSettingsQuery, User, UserSettingsDocument, UserSettingsQueryVariables } from '../graphql/generatedSDK';
+import { map } from 'rxjs/operators';
+import { UserService } from '../core/services/user.service';
+import { Observable, Subscription } from 'rxjs';
+import { MatButtonToggleChange, MatSlideToggleChange } from '@angular/material';
 
 @Component({
   selector: 'app-settings',
   templateUrl: './settings.component.html',
   styleUrls: ['./settings.component.scss'],
 })
-export class SettingsComponent implements OnInit {
-  constructor() {}
+export class SettingsComponent implements OnInit, OnDestroy {
+  email = false;
+  receiveAcross = false;
+  shareAcross = false;
+  loading = true;
+  userProfile: User;
+  subscription: Subscription;
+
+  constructor(private router: Router, private api: CceSDK, private userService: UserService) {}
 
   ngOnInit() {
     window.scrollTo(0, 0);
+    this.userProfile = this.userService.getCurrentUserProfile();
+    this.subscription = this.api.userSettingsWatch({ userId: this.userProfile.id }).valueChanges.subscribe((result) => {
+      const { receiveAcrossRoleBoundary, sendEmailMatchNotifications, shareAcrossRoleBoundary } = result.data.user;
+      this.loading = false;
+      this.receiveAcross = receiveAcrossRoleBoundary;
+      this.shareAcross = shareAcrossRoleBoundary;
+      this.email = sendEmailMatchNotifications;
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
+  }
+
+  back() {
+    this.router.navigate(['/account']);
+  }
+
+  toggleEmail({ checked }: MatSlideToggleChange) {
+    const matchRadius = this.userProfile.matchRadius || this.userProfile.dropOffRadius || this.userProfile.pickupRadius;
+    this.api
+      .updateUserSettings(
+        {
+          input: {
+            userId: this.userProfile.id,
+            address: this.userProfile.address,
+            city: this.userProfile.city,
+            emailAddress: this.userProfile.emailAddress,
+            currentUserEmail: this.userProfile.emailAddress,
+            firstName: this.userProfile.firstName,
+            lastName: this.userProfile.lastName,
+            state: this.userProfile.state,
+            postalCode: this.userProfile.postalCode,
+            phoneNumber: this.userProfile.phoneNumber,
+            matchRadius,
+            pickupRadius: this.userProfile.pickupRadius || matchRadius,
+            dropOffRadius: this.userProfile.dropOffRadius || matchRadius,
+            sendEmailMatchNotifications: checked,
+            sendEmailMessageNotifications: checked,
+          },
+        },
+        {
+          refetchQueries: [
+            {
+              query: UserSettingsDocument,
+              variables: {
+                userId: this.userProfile.id,
+              } as UserSettingsQueryVariables,
+            },
+          ],
+        }
+      )
+      .subscribe();
+  }
+
+  toggleReceiveFrom() {
+    // TODO
+  }
+  toggleShareAcross() {
+    // TODO
   }
 }

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -18,12 +18,14 @@ export class SettingsComponent implements OnInit, OnDestroy {
   loading = true;
   userProfile: User;
   subscription: Subscription;
+  isUser = true;
 
   constructor(private router: Router, private api: CceSDK, private userService: UserService) {}
 
   ngOnInit() {
     window.scrollTo(0, 0);
     this.userProfile = this.userService.getCurrentUserProfile();
+    this.isUser = !this.userProfile.organization;
     this.subscription = this.api.userSettingsWatch({ userId: this.userProfile.id }).valueChanges.subscribe((result) => {
       const { receiveAcrossRoleBoundary, sendEmailMatchNotifications, shareAcrossRoleBoundary } = result.data.user;
       this.loading = false;

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -1,0 +1,14 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-settings',
+  templateUrl: './settings.component.html',
+  styleUrls: ['./settings.component.scss'],
+})
+export class SettingsComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit() {
+    window.scrollTo(0, 0);
+  }
+}


### PR DESCRIPTION
I am off for a couple weeks and won't have much computer time. Wanted to leave this here for someone else to pick up.

Main things that need to happen are:

- [ ] figure out graphql mutation for the share/receive across boundary fields
- [ ] make sure the mutation result updates the apollo store and re-renders the view
- [x] add conditional labels to the share/receive based on user type (org sees individuals, individual sees organizations)
- [ ] add the checkmark button at the bottom of the screen and verify behavior  (should the mutation happen on the  toggle click, or altogether with the checkmark button?)

Notes:

* it seems unnecessarily hard to custom style material components, like make the switch green and add margin between the label and the switch, so I just left it with the default API and set the color to `primary`.
* in my mind, there should be a more liberal mutation other than `saveUser` where the only required field on the input is the `userId`. It's super bulky to have to pull in the entire user profile just to flip a boolean.
* I wasn't able to grok how to do what is called a "controlled component" in react land. I'm able to toggle the switch for toggles that have no change handler, which wouldn't happen in a react controlled component.
* I kept having to scan harder than I would expect to make sure the button and headings on the `/account` screen were correct, so I modified the html structure and styles to make the groupings more clear.

### current spacing
<img width="510" alt="Screen Shot 2020-07-31 at 5 27 13 PM" src="https://user-images.githubusercontent.com/19894032/89078848-284b6f00-d353-11ea-9a06-52ce894b1e05.png">

### proposed spacing
<img width="474" alt="Screen Shot 2020-07-31 at 5 26 39 PM" src="https://user-images.githubusercontent.com/19894032/89078855-2b465f80-d353-11ea-936b-b2b0b12ab5d6.png">
